### PR TITLE
Fix useEffect import in RegisterPage component

### DIFF
--- a/src/pages/auth/RegisterPage.tsx
+++ b/src/pages/auth/RegisterPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { BookOpen, User, Mail, Phone, MapPin, Calendar, Upload, AlertCircle, CheckCircle, Eye, EyeOff, Lock } from 'lucide-react';


### PR DESCRIPTION
## Purpose
Fix a critical runtime error in the RegisterPage component where `useEffect` was being used but not imported from React. The error was preventing the registration page from loading and causing the entire component to crash with "useEffect is not defined" reference error.

## Code changes
- Added `useEffect` to the React import statement in `RegisterPage.tsx`
- Updated import from `import React, { useState }` to `import React, { useEffect, useState }`To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 21`

🔗 [Edit in Builder.io](https://builder.io/app/projects/8a58c169caeb408f9cacb7afb40af29f/neon-nest)

👀 [Preview Link](https://8a58c169caeb408f9cacb7afb40af29f-neon-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8a58c169caeb408f9cacb7afb40af29f</projectId>-->
<!--<branchName>neon-nest</branchName>-->